### PR TITLE
Move require to suggests

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -9,7 +9,7 @@
 			"email": "hamish@silverstripe.com"
 		}
 	],
-	"require": {
+	"suggest": {
 		"silverstripe/framework": "*",
 		"silverstripe/fulltextsearch": "*"
 	},


### PR DESCRIPTION
- The "require" are not actually required to run this Solr instance
- Although mainly used for SilverStripe, it actually works stand-alone